### PR TITLE
Adding ALSA volume control

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -92,7 +92,7 @@ Ex: It takes around 60ms on my mac to launch the audio stream at the **Anchor Ti
 
 `alsa` (alsa port name) to replace default pcm port (default : pcm.default)
 
-`alsamixer` (alsa mixer name) Enables ALSA volume control (default : disabled)
+`alsamixer` (alsa mixer control) used for volume control (default : disabled)
 
 ```shell
 ./goplay2 -alsa pcm.default -i en0 -n aiwa

--- a/README.MD
+++ b/README.MD
@@ -92,7 +92,7 @@ Ex: It takes around 60ms on my mac to launch the audio stream at the **Anchor Ti
 
 `alsa` (alsa port name) to replace default pcm port (default : pcm.default)
 
-`alsamixer` (alsa mixer name) Enableds ALSA volume control (default : disabled)
+`alsamixer` (alsa mixer name) Enables ALSA volume control (default : disabled)
 
 ```shell
 ./goplay2 -alsa pcm.default -i en0 -n aiwa

--- a/README.MD
+++ b/README.MD
@@ -92,6 +92,8 @@ Ex: It takes around 60ms on my mac to launch the audio stream at the **Anchor Ti
 
 `alsa` (alsa port name) to replace default pcm port (default : pcm.default)
 
+`alsamixer` (alsa mixer name) Enableds ALSA volume control (default : disabled)
+
 ```shell
 ./goplay2 -alsa pcm.default -i en0 -n aiwa
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,8 @@ package config
 
 type Configuration struct {
 	AlsaPortName string
+	AlsaMixerName string
+	DeviceName string
 }
 
 var Config Configuration

--- a/main.go
+++ b/main.go
@@ -20,15 +20,15 @@ import (
 
 func main() {
 	var ifName string
-	var deviceName string
 	var syncLogFile string
 	var delay int64
 
 	flag.StringVar(&ifName, "i", "eth0", "Specify interface")
 	flag.Int64Var(&delay, "delay", 50, "Specify hardware delay in ms (useful on slow computer)")
-	flag.StringVar(&deviceName, "n", "goplay", "Specify device name")
+	flag.StringVar(&config.Config.DeviceName, "n", "goplay", "Specify device name")
 	flag.StringVar(&syncLogFile, "sync", "/dev/null", "Specify audio sync log")
 	flag.StringVar(&config.Config.AlsaPortName, "alsa", "pcm.default", "Specify Alsa Device - Linux only")
+	flag.StringVar(&config.Config.AlsaMixerName, "alsamixer", "disabled", "Specify Alsa Mixer Control - Linux only")
 	flag.Parse() // after declaring flags we need to call it
 
 	globals.ErrLog = log.New(os.Stderr, "Error:", log.LstdFlags|log.Lshortfile|log.Lmsgprefix)
@@ -51,11 +51,11 @@ func main() {
 			ipStringAddr = append(ipStringAddr, v.IP.String())
 		}
 	}
-	homekit.Device = homekit.NewAccessory(macAddress, deviceName, airplayDevice())
+	homekit.Device = homekit.NewAccessory(macAddress, config.Config.DeviceName, airplayDevice())
 	log.Printf("Starting goplay for device %v", homekit.Device)
-	homekit.Server, err = homekit.NewServer(macAddress, deviceName, ipStringAddr)
+	homekit.Server, err = homekit.NewServer(macAddress, config.Config.DeviceName, ipStringAddr)
 
-	server, err := zeroconf.Register(deviceName, "_airplay._tcp", "local.",
+	server, err := zeroconf.Register(config.Config.DeviceName, "_airplay._tcp", "local.",
 		7000, homekit.Device.ToRecords(), []net.Interface{*iFace})
 	if err != nil {
 		panic(err)
@@ -93,7 +93,7 @@ func main() {
 	}()
 
 	go func() {
-		handler, e := handlers.NewRstpHandler(deviceName, player)
+		handler, e := handlers.NewRstpHandler(config.Config.DeviceName, player)
 		if e != nil {
 			panic(e)
 		}


### PR DESCRIPTION
This PR adds support for volume control. It adds the ```---alsamixer``` command line option and if supplied it will control the volume. If not, volume control is disabled. The volume state is also stored and persists between sessions.

The easiest way to find the mixer name is to run alsamixer while playing some music and play around with all the sliders until you find the correct control. Take note of the name of the control at the bottom. That will be the name you would supply with the ```--alsamixer``` option.

This is my first stab at Go Lang so I'm sure my code could be streamlined. But it does work at least. :)