### PR TITLE
Conf dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,14 +21,19 @@ import (
 func main() {
 	var ifName string
 	var delay int64
+	var configurationBaseDir string
 
+	flag.StringVar(&configurationBaseDir, "c", ".", "Configuration base directory (default to current directory)")
 	flag.StringVar(&config.Config.DeviceName, "n", "goplay", "Specify device name")
 	flag.StringVar(&ifName, "i", "eth0", "Specify interface")
 	flag.Int64Var(&delay, "delay", 0, "Specify hardware delay in ms")
 	flag.StringVar(&config.Config.PulseSink, "sink", config.Config.PulseSink, "Specify Pulse Audio Sink - Linux only")
 	flag.Parse() // after declaring flags we need to call it
 
-	config.Config.Load()
+	err := config.Config.Load(configurationBaseDir)
+	if err != nil {
+		panic(err)
+	}
 	defer config.Config.Store()
 
 	globals.ErrLog = log.New(os.Stderr, "Error:", log.LstdFlags|log.Lshortfile|log.Lmsgprefix)

--- a/pairing/controller.go
+++ b/pairing/controller.go
@@ -1,10 +1,11 @@
 package pairing
 
 import (
-	"fmt"
 	"github.com/brutella/hc/db"
 	"github.com/brutella/hc/hap/pair"
 	"github.com/brutella/hc/util"
+	"goplay2/config"
+	"path/filepath"
 )
 
 type Controller struct {
@@ -37,7 +38,7 @@ func (c Controller) Handle(cont util.Container) (util.Container, error) {
 }
 
 func NewController(deviceName string) (*Controller, error) {
-	storage, err := util.NewFileStorage(fmt.Sprintf("%s/db", deviceName))
+	storage, err := util.NewFileStorage(filepath.Join(config.Config.DataDirectory, "db", deviceName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix #20 

New flag -c allows one to point to a base directory where configuration will live.

If unspecified, pwd will be used, which should match the previous behavior.

This is just a quick suggestion at this point, but I thought I would send it over early for feedback / modifications.