### PR TITLE
Fix build bustage and better README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Single source stage
-FROM    --platform=$BUILDPLATFORM golang:1.16   as fetcher
+FROM    --platform=$BUILDPLATFORM golang:1.16-buster   as fetcher
 
 # Bring the source in
 COPY    . "$GOPATH"/src/github.com/albanseurat/goplay2

--- a/README.MD
+++ b/README.MD
@@ -88,12 +88,16 @@ You can build and run the image to quickly test goplay, though this is experimen
 The following platforms are supported: linux/amd64, linux/arm64, linux/arm/v7.
 Other platforms should also build.
 
-You can build with docker directly:
+You need at least docker 19.06.
+
+To build:
 ```shell
-docker build --platform=linux/amd64 -t you/goplay2 .
+docker buildx build -t you/goplay2 .
 ```
 
-Or with buildctl / buildkit if you want to assemble a multi-arch image.
+This is a multi-architecture image.
+If you have QEMU/Docker configured, you can target a different platform,
+or better, use buildctl and buildkit to produce a proper multi-architecture image.
 
 * Run the container
 


### PR DESCRIPTION
- maintainers of the golang image moved the image to bullseye, so, force-pinning to buster for now (libfdk1 vs. libfdk2)
- simplified readme for newcomers, removing the target architecture part that was apparently confusing

@AlbanSeurat 