### PR TITLE
fix: remove difference between linux and macOS paths

### DIFF
--- a/codec/aac.go
+++ b/codec/aac.go
@@ -26,11 +26,7 @@ package codec
 
 #cgo pkg-config: fdk-aac
 
-#ifdef __linux__
 #include "fdk-aac/aacdecoder_lib.h"
-#else
-#include "aacdecoder_lib.h"
-#endif
 
 typedef struct {
 	HANDLE_AACDECODER dec;


### PR DESCRIPTION
Since brew symlinks fdk-aac under `/usr/local/include/` it isn't necessary to split the include for Linux and macOS systems as long as the user has properly configured brew on their system.

For macOS you need to be sure that you have `/usr/local/include` in your path.

```
➜  ~ tree /usr/local/include/fdk-aac
/usr/local/include/fdk-aac
├── FDK_audio.h
├── aacdecoder_lib.h
├── aacenc_lib.h
├── genericStds.h
├── machine_type.h
└── syslib_channelMapDescr.h

0 directories, 6 files
```

Inside bashrc/zshrc:

```
export PATH="/usr/local/include:$PATH"
```