### PR TITLE
fix: avoid shifting the list to prevent sigsegv

### DIFF
--- a/audio/ring.go
+++ b/audio/ring.go
@@ -155,13 +155,7 @@ func (r *Ring) Filter(predicate func(sequence uint32, startTs uint32) bool) {
 	for e := r.buffers.Front(); e != nil; e = e.Next() {
 		elem := e.Value.(*markedBuffer)
 		if predicate(elem.sequence, elem.startTs) {
-			prev := e.Prev()
 			r.buffers.Remove(e)
-			if prev == nil {
-				e = r.buffers.Front()
-			} else {
-				e = prev
-			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #31 

Avoid shifting the list since container/list has already logic on the remove method.

Source: https://github.com/golang/go/blob/master/src/container/list/list.go

